### PR TITLE
Slim :shortcut string values are deprecated

### DIFF
--- a/lib/role-rails/engine.rb
+++ b/lib/role-rails/engine.rb
@@ -2,7 +2,7 @@ module RoleRails
   class Engine < ::Rails::Engine
     initializer "role-rails.register" do |app|
       if defined?(Slim::Parser)
-        Slim::Parser.default_options[:shortcut].try(:[]=, '@', 'role')
+        Slim::Parser.default_options[:shortcut].try(:[]=, '@', :attr => 'role')
       end
 
       if defined?(Slim::Engine)


### PR DESCRIPTION
We have this error message almost everywhere:

```
Slim :shortcut string values are deprecated, use hash like { '#' => { :tag => 'div', :attr => 'id' } }
```

WARNING! 
This pull request crashes tests because of Skim gem (which is a development dependency): it requires Slim 1.2.2, but there was no such feature in such old version. Here is an issue about this https://github.com/jfirebaugh/skim/issues/23, so skim is not going to support newer versions of Slim. 
