### PR TITLE
Remove deprecation warning from Temple

### DIFF
--- a/lib/role-rails/engine.rb
+++ b/lib/role-rails/engine.rb
@@ -2,11 +2,11 @@ module RoleRails
   class Engine < ::Rails::Engine
     initializer "role-rails.register" do |app|
       if defined?(Slim::Parser)
-        Slim::Parser.default_options[:shortcut].try(:[]=, '@', :attr => 'role')
+        Slim::Parser.options[:shortcut].try(:[]=, '@', :attr => 'role')
       end
 
       if defined?(Slim::Engine)
-        Slim::Engine.default_options[:merge_attrs].try(:[]=, 'role', ' ')
+        Slim::Engine.options[:merge_attrs].try(:[]=, 'role', ' ')
       end
     end
   end

--- a/role-rails.gemspec
+++ b/role-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rails", ">= 3.1.0"
 
-  gem.add_development_dependency "slim", "~> 2.0.0"
+  gem.add_development_dependency "slim", ">= 3.0.0"
   gem.add_development_dependency "skim", "~> 0.9.0"
   gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "shoulda"


### PR DESCRIPTION
`Slim::Parser.default_options` is deprecated, `Slim::Parser.options` should be used
