### PR TITLE
Make gem compatible with newer versions of Slim (>= 3.0.0)

### DIFF
--- a/lib/role-rails/engine.rb
+++ b/lib/role-rails/engine.rb
@@ -2,12 +2,16 @@ module RoleRails
   class Engine < ::Rails::Engine
     initializer "role-rails.register" do |app|
       if defined?(Slim::Parser)
-        Slim::Parser.default_options[:shortcut].try(:[]=, '@', :attr => 'role')
+        Slim::Parser.send(slim_options)[:shortcut].try(:[]=, '@', :attr => 'role')
       end
 
       if defined?(Slim::Engine)
-        Slim::Engine.default_options[:merge_attrs].try(:[]=, 'role', ' ')
+        Slim::Engine.send(slim_options)[:merge_attrs].try(:[]=, 'role', ' ')
       end
+    end
+
+    def slim_options
+      Slim::VERSION.to_i >= 3 ? "options" : "default_options"
     end
   end
 end


### PR DESCRIPTION
Since v3 Slim do not support (or at least marks as deprecated) `default_options` method – use `options` instead. Otherwise, Slim raises `default_options has been deprecated, use options` exception.
